### PR TITLE
Update bundle to support mjs and cjs applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,24 +2,20 @@
   "name": "basyx-typescript-sdk",
   "version": "1.0.0",
   "description": "BaSyx TypeScript SDK for developing applications and components for the Asset Administration Shell (AAS)",
-  "type": "module",
-  "main": "bundle/index.js",
+  "main": "bundle/index.cjs",
+  "module": "bundle/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./bundle/index.js",
+      "import": "./bundle/index.mjs",
+      "require": "./bundle/index.cjs",
       "types": "./dist/index.d.ts"
     }
   },
   "repository": "https://github.com/eclipse-basyx/basyx-typescript-sdk.git",
   "author": "Aaron Zielstorff <aaron.zielstorff@iese.fraunhofer.de>",
   "license": "MIT",
-  "files": [
-    "bundle",
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["bundle", "dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc",
     "bundle": "rollup -c",
@@ -34,7 +30,6 @@
     "gen-smregistry": "openapi-generator-cli generate -i openapi/smregistry.yaml -g typescript-fetch -o src/generated/SubmodelRegistryService --additional-properties=withoutRuntimeChecks=true",
     "gen-aasdiscovery": "openapi-generator-cli generate -i openapi/aasdiscovery.yaml -g typescript-fetch -o src/generated/AasDiscoveryService --additional-properties=withoutRuntimeChecks=true",
     "gen-aasxfileserver": "openapi-generator-cli generate -i openapi/aasxfileserver.yaml -g typescript-fetch -o src/generated/AasxFileService --additional-properties=withoutRuntimeChecks=true"
-
   },
   "peerDependencies": {
     "@aas-core-works/aas-core3.0-typescript": "^1.0.3"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,12 +1,26 @@
 import resolve from '@rollup/plugin-node-resolve';
 
-export default {
-    input: 'dist/index.js',
-    output: {
-        file: 'bundle/index.js',
-        format: 'esm',
-        sourcemap: true,
+export default [
+    // CommonJS build
+    {
+        input: 'dist/index.js',
+        output: {
+            file: 'bundle/index.cjs',
+            format: 'cjs',
+            sourcemap: true,
+        },
+        plugins: [resolve()],
+        external: ['@aas-core-works/aas-core3.0-typescript', '@hey-api/client-fetch'],
     },
-    plugins: [resolve()],
-    external: ['@aas-core-works/aas-core3.0-typescript', '@hey-api/client-fetch'],
-};
+    // ES Module build
+    {
+        input: 'dist/index.js',
+        output: {
+            file: 'bundle/index.mjs',
+            format: 'esm',
+            sourcemap: true,
+        },
+        plugins: [resolve()],
+        external: ['@aas-core-works/aas-core3.0-typescript', '@hey-api/client-fetch'],
+    },
+];


### PR DESCRIPTION
- Updates package.json to specify separate entry points for CommonJS and ES Module formats.
- Modifies rollup.config.mjs to create distinct builds for CommonJS and ES Module outputs, enhancing compatibility.