### PR TITLE
Minor bundle fix and version bump to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basyx-typescript-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "BaSyx TypeScript SDK for developing applications and components for the Asset Administration Shell (AAS)",
   "main": "bundle/index.cjs",
   "module": "bundle/index.mjs",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,7 +16,7 @@ export default [
             }),
             resolve(),
         ],
-        external: ['@aas-core-works/aas-core3.1-typescript', '@hey-api/client-fetch'],
+        external: ['@hey-api/client-fetch'],
     },
     // ES Module build
     {
@@ -32,6 +32,6 @@ export default [
             }),
             resolve(),
         ],
-        external: ['@aas-core-works/aas-core3.1-typescript', '@hey-api/client-fetch'],
+        external: ['@hey-api/client-fetch'],
     },
 ];


### PR DESCRIPTION
This pull request makes a minor version bump to the SDK and updates the build configuration to remove an unnecessary external dependency. These changes help ensure the package version reflects the latest updates and streamline the build process.

Build configuration update:

* Removed `@aas-core-works/aas-core3.1-typescript` from the `external` array in both the CommonJS and ES Module builds in `rollup.config.mjs`, so it is now bundled rather than treated as an external dependency. [[1]](diffhunk://#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1L19-R19) [[2]](diffhunk://#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1L35-R35)

Version update:

* Bumped the package version from `2.2.1` to `2.2.2` in `package.json` to reflect these changes.