### PR TITLE
Improves AAS Registry test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:integration": "vitest run --project integration-tests",
     "validate:openapi-coverage": "node scripts/validate-openapi-coverage.mjs",
     "validate:openapi-coverage:aasdiscovery": "node scripts/validate-openapi-coverage.mjs --service aasDiscovery",
+    "validate:openapi-coverage:aasregistry": "node scripts/validate-openapi-coverage.mjs --service aasRegistry",
     "validate:openapi-coverage:smregistry": "node scripts/validate-openapi-coverage.mjs --service submodelRegistry",
     "docs": "typedoc --options typedoc.json",
     "gen-aasrepo": "openapi-generator-cli generate -i openapi/aasrepository.yaml -g typescript-fetch -o src/generated/AasRepositoryService --additional-properties=withoutRuntimeChecks=true",

--- a/scripts/validate-openapi-coverage.mjs
+++ b/scripts/validate-openapi-coverage.mjs
@@ -13,6 +13,11 @@ const SERVICE_CONFIG = {
         clientFile: 'src/clients/AasDiscoveryClient.ts',
         integrationTestFile: 'src/integration-tests/aasDiscovery.integration.test.ts',
     },
+    aasRegistry: {
+        openapiFile: 'openapi/aasregistry.yaml',
+        clientFile: 'src/clients/AasRegistryClient.ts',
+        integrationTestFile: 'src/integration-tests/aasRegistry.integration.test.ts',
+    },
     submodelRegistry: {
         openapiFile: 'openapi/smregistry.yaml',
         clientFile: 'src/clients/SubmodelRegistryClient.ts',
@@ -36,6 +41,13 @@ function parseArgs(argv) {
 
 function lcFirst(value) {
     return value.charAt(0).toLowerCase() + value.slice(1);
+}
+
+function operationIdToMethodName(operationId) {
+    const normalized = operationId.replace(/[^A-Za-z0-9]+(.)?/g, (_, nextChar) =>
+        nextChar ? nextChar.toUpperCase() : ''
+    );
+    return lcFirst(normalized);
 }
 
 function parseOpenApiOperations(openapiSource) {
@@ -127,7 +139,7 @@ function parseIntegrationMetadata(testSource) {
         }
 
         const body = testSource.slice(openBraceIndex + 1, closeBraceIndex);
-        const operationMatch = jsdoc.match(/@operation\s+([A-Za-z0-9_]+)/);
+        const operationMatch = jsdoc.match(/@operation\s+([A-Za-z0-9_-]+)/);
         if (!operationMatch) {
             continue;
         }
@@ -218,7 +230,7 @@ function buildCoverageReport(operations, clientMethods, testMetadata) {
     const warnings = [];
 
     for (const operation of operations) {
-        const expectedMethodName = lcFirst(operation.operationId);
+        const expectedMethodName = operationIdToMethodName(operation.operationId);
         const implemented = clientMethods.has(expectedMethodName);
         const coverage = operationCoverage.get(operation.operationId);
         const assertedStatuses = coverage?.assertedStatuses ?? new Set();

--- a/src/clients/AasDiscoveryClient.ts
+++ b/src/clients/AasDiscoveryClient.ts
@@ -2,7 +2,7 @@ import type { SpecificAssetId } from '@aas-core-works/aas-core3.1-typescript/typ
 import type { ApiResult } from '../models/api';
 import type { AssetId } from '../models/AssetId';
 import { AasDiscoveryService } from '../generated';
-import { Configuration, RequiredError, ResponseError } from '../generated/runtime';
+import { Configuration, RequiredError } from '../generated/runtime';
 import { applyDefaults } from '../lib/apiConfig';
 import { base64Encode } from '../lib/base64Url';
 import { convertApiAssetIdToCoreAssetId, convertCoreAssetIdToApiAssetId } from '../lib/convertAasDiscoveryTypes';

--- a/src/clients/AasDiscoveryClient.ts
+++ b/src/clients/AasDiscoveryClient.ts
@@ -10,11 +10,12 @@ import { handleApiError } from '../lib/errorHandler';
 
 export class AasDiscoveryClient {
     private static extractStatusCode(err: unknown, parsedError?: AasDiscoveryService.Result): number | undefined {
-        if (err instanceof ResponseError) {
-            return err.response.status;
+        const responseStatus = (err as { response?: { status?: unknown } })?.response?.status;
+        if (typeof responseStatus === 'number') {
+            return responseStatus;
         }
 
-        if (err instanceof RequiredError) {
+        if (err instanceof RequiredError || (err as { name?: unknown })?.name === 'RequiredError') {
             return 400;
         }
 

--- a/src/clients/AasRegistryClient.ts
+++ b/src/clients/AasRegistryClient.ts
@@ -1,7 +1,7 @@
 //import type { AssetKind } from '@aas-core-works/aas-core3.1-typescript/types';
 import type { ApiResult } from '../models/api';
 import { AasRegistryService } from '../generated';
-import { Configuration } from '../generated/runtime';
+import { Configuration, RequiredError } from '../generated/runtime';
 import { applyDefaults } from '../lib/apiConfig';
 import { base64Encode } from '../lib/base64Url';
 import {
@@ -14,6 +14,33 @@ import { handleApiError } from '../lib/errorHandler';
 import { AssetAdministrationShellDescriptor, SubmodelDescriptor } from '../models/Descriptors';
 
 export class AasRegistryClient {
+    private static requireIdentifier(value: string | null | undefined, field: string): string {
+        if (value === null || value === undefined || value.trim() === '') {
+            throw new RequiredError(field, `Required parameter "${field}" was null, undefined, or empty.`);
+        }
+
+        return value;
+    }
+
+    private static extractStatusCode(err: unknown, parsedError?: AasRegistryService.Result): number | undefined {
+        const responseStatus = (err as { response?: { status?: unknown } })?.response?.status;
+        if (typeof responseStatus === 'number') {
+            return responseStatus;
+        }
+
+        if (err instanceof RequiredError || (err as { name?: unknown })?.name === 'RequiredError') {
+            return 400;
+        }
+
+        const code = parsedError?.messages?.[0]?.code;
+        if (!code) {
+            return undefined;
+        }
+
+        const parsedCode = Number.parseInt(code, 10);
+        return Number.isNaN(parsedCode) ? undefined : parsedCode;
+    }
+
     /**
      * Returns all Asset Administration Shell Descriptors
      *
@@ -49,21 +76,27 @@ export class AasRegistryClient {
             );
             const encodedAssetType = assetType ? base64Encode(assetType) : undefined;
 
-            const result = await apiInstance.getAllAssetAdministrationShellDescriptors({
+            const response = await apiInstance.getAllAssetAdministrationShellDescriptorsRaw({
                 limit: limit,
                 cursor: cursor,
                 assetKind: assetKind,
                 assetType: encodedAssetType,
             });
+            const result = await response.value();
             const aasDescriptors = (result.result ?? []).map(convertApiAasDescriptorToCoreAasDescriptor);
 
             return {
                 success: true,
                 data: { pagedResult: result.pagingMetadata, result: aasDescriptors },
+                statusCode: response.raw.status,
             };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -87,16 +120,25 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const result = await apiInstance.postAssetAdministrationShellDescriptor({
+            const response = await apiInstance.postAssetAdministrationShellDescriptorRaw({
                 assetAdministrationShellDescriptor: convertCoreAasDescriptorToApiAasDescriptor(
                     assetAdministrationShellDescriptor
                 ),
             });
+            const result = await response.value();
 
-            return { success: true, data: convertApiAasDescriptorToCoreAasDescriptor(result) };
+            return {
+                success: true,
+                data: convertApiAasDescriptorToCoreAasDescriptor(result),
+                statusCode: response.raw.status,
+            };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -120,16 +162,23 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
 
-            const result = await apiInstance.deleteAssetAdministrationShellDescriptorById({
+            const response = await apiInstance.deleteAssetAdministrationShellDescriptorByIdRaw({
                 aasIdentifier: encodedAasIdentifier,
             });
+            const result = await response.value();
 
-            return { success: true, data: result };
+            return { success: true, data: result, statusCode: response.raw.status };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -153,16 +202,27 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
 
-            const result = await apiInstance.getAssetAdministrationShellDescriptorById({
+            const response = await apiInstance.getAssetAdministrationShellDescriptorByIdRaw({
                 aasIdentifier: encodedAasIdentifier,
             });
+            const result = await response.value();
 
-            return { success: true, data: convertApiAasDescriptorToCoreAasDescriptor(result) };
+            return {
+                success: true,
+                data: convertApiAasDescriptorToCoreAasDescriptor(result),
+                statusCode: response.raw.status,
+            };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -188,19 +248,35 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
 
-            const result = await apiInstance.putAssetAdministrationShellDescriptorById({
+            const response = await apiInstance.putAssetAdministrationShellDescriptorByIdRaw({
                 aasIdentifier: encodedAasIdentifier,
                 assetAdministrationShellDescriptor: convertCoreAasDescriptorToApiAasDescriptor(
                     assetAdministrationShellDescriptor
                 ),
             });
 
-            return { success: true, data: result ? convertApiAasDescriptorToCoreAasDescriptor(result) : undefined };
+            if (response.raw.status === 204) {
+                return { success: true, data: undefined, statusCode: response.raw.status };
+            }
+
+            const result = await response.value();
+
+            return {
+                success: true,
+                data: result ? convertApiAasDescriptorToCoreAasDescriptor(result) : undefined,
+                statusCode: response.raw.status,
+            };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -235,22 +311,30 @@ export class AasRegistryClient {
             const apiInstance = new AasRegistryService.AssetAdministrationShellRegistryAPIApi(
                 applyDefaults(configuration)
             );
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
 
-            const result = await apiInstance.getAllSubmodelDescriptorsThroughSuperpath({
+            const response = await apiInstance.getAllSubmodelDescriptorsThroughSuperpathRaw({
                 aasIdentifier: encodedAasIdentifier,
                 limit: limit,
                 cursor: cursor,
             });
+            const result = await response.value();
             const submodelDescriptors = (result.result ?? []).map(convertApiSubmodelDescriptorToCoreSubmodelDescriptor);
 
             return {
                 success: true,
                 data: { pagedResult: result.pagingMetadata, result: submodelDescriptors },
+                statusCode: response.raw.status,
             };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -276,17 +360,28 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
 
-            const result = await apiInstance.postSubmodelDescriptorThroughSuperpath({
+            const response = await apiInstance.postSubmodelDescriptorThroughSuperpathRaw({
                 aasIdentifier: encodedAasIdentifier,
                 submodelDescriptor: convertCoreSubmodelDescriptorToApiSubmodelDescriptor(submodelDescriptor),
             });
+            const result = await response.value();
 
-            return { success: true, data: convertApiSubmodelDescriptorToCoreSubmodelDescriptor(result) };
+            return {
+                success: true,
+                data: convertApiSubmodelDescriptorToCoreSubmodelDescriptor(result),
+                statusCode: response.raw.status,
+            };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -312,18 +407,31 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
+            const encodedSubmodelIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
-            const result = await apiInstance.getSubmodelDescriptorByIdThroughSuperpath({
+            const response = await apiInstance.getSubmodelDescriptorByIdThroughSuperpathRaw({
                 aasIdentifier: encodedAasIdentifier,
                 submodelIdentifier: encodedSubmodelIdentifier,
             });
+            const result = await response.value();
 
-            return { success: true, data: convertApiSubmodelDescriptorToCoreSubmodelDescriptor(result) };
+            return {
+                success: true,
+                data: convertApiSubmodelDescriptorToCoreSubmodelDescriptor(result),
+                statusCode: response.raw.status,
+            };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -349,18 +457,27 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
+            const encodedSubmodelIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
-            const result = await apiInstance.deleteSubmodelDescriptorByIdThroughSuperpath({
+            const response = await apiInstance.deleteSubmodelDescriptorByIdThroughSuperpathRaw({
                 aasIdentifier: encodedAasIdentifier,
                 submodelIdentifier: encodedSubmodelIdentifier,
             });
+            const result = await response.value();
 
-            return { success: true, data: result };
+            return { success: true, data: result, statusCode: response.raw.status };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -388,22 +505,37 @@ export class AasRegistryClient {
                 applyDefaults(configuration)
             );
 
-            const encodedAasIdentifier = base64Encode(aasIdentifier);
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedAasIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(aasIdentifier, 'aasIdentifier')
+            );
+            const encodedSubmodelIdentifier = base64Encode(
+                AasRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
-            const result = await apiInstance.putSubmodelDescriptorByIdThroughSuperpath({
+            const response = await apiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw({
                 aasIdentifier: encodedAasIdentifier,
                 submodelIdentifier: encodedSubmodelIdentifier,
                 submodelDescriptor: convertCoreSubmodelDescriptorToApiSubmodelDescriptor(submodelDescriptor),
             });
 
+            if (response.raw.status === 204) {
+                return { success: true, data: undefined, statusCode: response.raw.status };
+            }
+
+            const result = await response.value();
+
             return {
                 success: true,
                 data: result ? convertApiSubmodelDescriptorToCoreSubmodelDescriptor(result) : undefined,
+                statusCode: response.raw.status,
             };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 
@@ -422,12 +554,17 @@ export class AasRegistryClient {
 
         try {
             const apiInstance = new AasRegistryService.DescriptionAPIApi(applyDefaults(configuration));
-            const result = await apiInstance.getSelfDescription();
+            const response = await apiInstance.getSelfDescriptionRaw();
+            const result = await response.value();
 
-            return { success: true, data: result };
+            return { success: true, data: result, statusCode: response.raw.status };
         } catch (err) {
             const customError = await handleApiError(err);
-            return { success: false, error: customError };
+            return {
+                success: false,
+                error: customError,
+                statusCode: AasRegistryClient.extractStatusCode(err, customError),
+            };
         }
     }
 }

--- a/src/clients/SubmodelRegistryClient.ts
+++ b/src/clients/SubmodelRegistryClient.ts
@@ -1,6 +1,6 @@
 import type { ApiResult } from '../models/api';
 import { SubmodelRegistryService } from '../generated';
-import { Configuration, RequiredError, ResponseError } from '../generated/runtime';
+import { Configuration, RequiredError } from '../generated/runtime';
 import { applyDefaults } from '../lib/apiConfig';
 import { base64Encode } from '../lib/base64Url';
 import {

--- a/src/clients/SubmodelRegistryClient.ts
+++ b/src/clients/SubmodelRegistryClient.ts
@@ -11,12 +11,21 @@ import { handleApiError } from '../lib/errorHandler';
 import { SubmodelDescriptor } from '../models/Descriptors';
 
 export class SubmodelRegistryClient {
-    private static extractStatusCode(err: unknown, parsedError?: SubmodelRegistryService.Result): number | undefined {
-        if (err instanceof ResponseError) {
-            return err.response.status;
+    private static requireIdentifier(value: string | null | undefined, field: string): string {
+        if (value === null || value === undefined || value.trim() === '') {
+            throw new RequiredError(field, `Required parameter "${field}" was null, undefined, or empty.`);
         }
 
-        if (err instanceof RequiredError) {
+        return value;
+    }
+
+    private static extractStatusCode(err: unknown, parsedError?: SubmodelRegistryService.Result): number | undefined {
+        const responseStatus = (err as { response?: { status?: unknown } })?.response?.status;
+        if (typeof responseStatus === 'number') {
+            return responseStatus;
+        }
+
+        if (err instanceof RequiredError || (err as { name?: unknown })?.name === 'RequiredError') {
             return 400;
         }
 
@@ -135,7 +144,9 @@ export class SubmodelRegistryClient {
         try {
             const apiInstance = new SubmodelRegistryService.SubmodelRegistryAPIApi(applyDefaults(configuration));
 
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedSubmodelIdentifier = base64Encode(
+                SubmodelRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
             const response = await apiInstance.deleteSubmodelDescriptorByIdRaw({
                 submodelIdentifier: encodedSubmodelIdentifier,
@@ -171,7 +182,9 @@ export class SubmodelRegistryClient {
         try {
             const apiInstance = new SubmodelRegistryService.SubmodelRegistryAPIApi(applyDefaults(configuration));
 
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedSubmodelIdentifier = base64Encode(
+                SubmodelRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
             const response = await apiInstance.getSubmodelDescriptorByIdRaw({
                 submodelIdentifier: encodedSubmodelIdentifier,
@@ -213,7 +226,9 @@ export class SubmodelRegistryClient {
         try {
             const apiInstance = new SubmodelRegistryService.SubmodelRegistryAPIApi(applyDefaults(configuration));
 
-            const encodedSubmodelIdentifier = base64Encode(submodelIdentifier);
+            const encodedSubmodelIdentifier = base64Encode(
+                SubmodelRegistryClient.requireIdentifier(submodelIdentifier, 'submodelIdentifier')
+            );
 
             const response = await apiInstance.putSubmodelDescriptorByIdRaw({
                 submodelIdentifier: encodedSubmodelIdentifier,

--- a/src/integration-tests/aasDiscovery.integration.test.ts
+++ b/src/integration-tests/aasDiscovery.integration.test.ts
@@ -106,6 +106,24 @@ describe('AAS Discovery Integration Tests', () => {
     });
 
     /**
+     * @operation GetAllAssetAdministrationShellIdsByAssetLink
+     * @status 400
+     */
+    test('should reject invalid AAS discovery lookup cursor with bad request', async () => {
+        const response = await client.getAllAssetAdministrationShellIdsByAssetLink({
+            configuration,
+            assetIds: [testSpecificAssetId1, testSpecificAssetId2],
+            cursor: `does-not-exist-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
      * @operation SearchAllAssetAdministrationShellIdsByAssetLink
      * @status 200
      */
@@ -130,6 +148,24 @@ describe('AAS Discovery Integration Tests', () => {
         const response = await client.searchAllAssetAdministrationShellIdsByAssetLink({
             configuration,
             assetLink: [{ name: 'globalAssetId' } as any],
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation SearchAllAssetAdministrationShellIdsByAssetLink
+     * @status 400
+     */
+    test('should reject invalid AAS discovery search cursor with bad request', async () => {
+        const response = await client.searchAllAssetAdministrationShellIdsByAssetLink({
+            configuration,
+            assetLink: [testSpecificAssetId1, testSpecificAssetId2],
+            cursor: `does-not-exist-${Date.now()}-${Math.random().toString(36).slice(2)}`,
         });
 
         expect(response.success).toBe(false);

--- a/src/integration-tests/aasRegistry.integration.test.ts
+++ b/src/integration-tests/aasRegistry.integration.test.ts
@@ -1,3 +1,4 @@
+import { AssetKind } from '@aas-core-works/aas-core3.1-typescript/types';
 import { AasRegistryClient } from '../clients/AasRegistryClient';
 import { Configuration } from '../generated';
 import {
@@ -9,192 +10,811 @@ import {
 
 describe('AAS Registry Integration Tests', () => {
     const client = new AasRegistryClient();
-    const testShellDescriptor = createTestShellDescriptor();
-    const testSubmodelDescriptor = createTestSubmodelDescriptor();
     const configuration = new Configuration({
         basePath: 'http://localhost:8084',
     });
 
+    const uniqueSuffix = (): string => `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const createUniqueShellDescriptor = () => {
+        const descriptor = createTestShellDescriptor();
+        descriptor.id = `${descriptor.id}-${uniqueSuffix()}`;
+        return descriptor;
+    };
+
+    const createInvalidShellDescriptorWithEmptyId = () => {
+        const descriptor = createUniqueShellDescriptor();
+        descriptor.id = '';
+        descriptor.assetKind = AssetKind.Type;
+        descriptor.assetType = 'Type';
+        descriptor.globalAssetId = `https://example.com/ids/assets/${uniqueSuffix()}`;
+        descriptor.idShort = 'InvalidConnectorDescriptor';
+        descriptor.specificAssetIds = [];
+        descriptor.endpoints = [
+            {
+                _interface: 'AAS-3.0',
+                protocolInformation: {
+                    href: 'https://example.com/shells/invalid',
+                    endpointProtocol: 'http',
+                    endpointProtocolVersion: null,
+                    subprotocol: null,
+                    subprotocolBody: null,
+                    subprotocolBodyEncoding: null,
+                    securityAttributes: null,
+                },
+            },
+        ];
+        return descriptor;
+    };
+
+    const createUniqueSubmodelDescriptor = () => {
+        const descriptor = createTestSubmodelDescriptor();
+        descriptor.id = `${descriptor.id}-${uniqueSuffix()}`;
+        return descriptor;
+    };
+
+    /**
+     * @operation PostAssetAdministrationShellDescriptor
+     * @status 201
+     */
     test('should create a new Asset Administration Shell Descriptor', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+
         const response = await client.postAssetAdministrationShellDescriptor({
             configuration,
-            assetAdministrationShellDescriptor: testShellDescriptor,
+            assetAdministrationShellDescriptor: shellDescriptor,
         });
 
         expect(response.success).toBe(true);
         if (response.success) {
-            expect(response.data).toBeDefined();
-            expect(response.data).toEqual(testShellDescriptor);
+            expect(response.statusCode).toBe(201);
+            expect(response.data).toEqual(shellDescriptor);
         }
     });
 
-    test('should fetch an Asset Administration Shell Descriptor by ID', async () => {
-        const response = await client.getAssetAdministrationShellDescriptorById({
+    /**
+     * @operation PostAssetAdministrationShellDescriptor
+     * @status 400
+     */
+    test('should reject invalid Asset Administration Shell Descriptor payload with bad request', async () => {
+        const response = await client.postAssetAdministrationShellDescriptor({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
+            assetAdministrationShellDescriptor: createInvalidShellDescriptorWithEmptyId(),
         });
 
-        expect(response.success).toBe(true);
-        if (response.success) {
-            expect(response.data).toBeDefined();
-            expect(response.data).toEqual(testShellDescriptor);
-        }
-    });
-
-    test('should fetch an Asset Administration Shell Descriptor by non-existing ID', async () => {
-        const nonExistingId = 'non-existing-id';
-        const response = await client.getAssetAdministrationShellDescriptorById({
-            configuration,
-            aasIdentifier: nonExistingId,
-        });
         expect(response.success).toBe(false);
         if (!response.success) {
-            expect(response.error).toBeDefined();
-            console.log('Error:', response.error);
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
         }
     });
 
+    /**
+     * @operation PostAssetAdministrationShellDescriptor
+     * @status 409 [non-blocking]
+     */
+    test('should surface conflict status for duplicate AAS descriptor creation when backend enforces it', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+
+        const initialResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(initialResponse.success).toBe(true);
+
+        const duplicateResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+
+        if (duplicateResponse.success) {
+            expect([201, 204]).toContain(duplicateResponse.statusCode);
+        } else {
+            expect(duplicateResponse.statusCode).toBe(409);
+            expect(duplicateResponse.error.messages?.[0]?.code).toBe('409');
+        }
+    });
+
+    /**
+     * @operation GetAssetAdministrationShellDescriptorById
+     * @status 200
+     */
+    test('should fetch an Asset Administration Shell Descriptor by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createResponse.success).toBe(true);
+
+        const response = await client.getAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+        });
+
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(200);
+            expect(response.data).toEqual(shellDescriptor);
+        }
+    });
+
+    /**
+     * @operation GetAssetAdministrationShellDescriptorById
+     * @status 400
+     */
+    test('should reject missing AAS identifier with bad request', async () => {
+        const response = await client.getAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetAssetAdministrationShellDescriptorById
+     * @status 404
+     */
+    test('should return not found for a non-existing Asset Administration Shell Descriptor', async () => {
+        const response = await client.getAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: `https://example.com/ids/aas-desc/non-existing-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation GetAllAssetAdministrationShellDescriptors
+     * @status 200
+     */
     test('should fetch all Asset Administration Shell Descriptors', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createResponse.success).toBe(true);
+
         const response = await client.getAllAssetAdministrationShellDescriptors({
             configuration,
         });
 
         expect(response.success).toBe(true);
         if (response.success) {
-            expect(response.data).toBeDefined();
+            expect(response.statusCode).toBe(200);
             expect(response.data.result.length).toBeGreaterThan(0);
-            expect(response.data.result).toContainEqual(testShellDescriptor);
+            expect(response.data.result).toContainEqual(shellDescriptor);
         }
     });
 
-    test('should update an Asset Administration Shell Descriptor', async () => {
-        const updatedShellDescriptor = testShellDescriptor;
-        const description = createDescription();
-
-        updatedShellDescriptor.description = [description];
-        //updatedShellDescriptor.submodelDescriptors = [testSubmodelDescriptor];
-
-        const updateResponse = await client.putAssetAdministrationShellDescriptorById({
+    /**
+     * @operation GetAllAssetAdministrationShellDescriptors
+     * @status 400
+     */
+    test('should reject invalid AAS descriptor paging parameters with bad request', async () => {
+        const response = await client.getAllAssetAdministrationShellDescriptors({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
+            limit: -1,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetAllAssetAdministrationShellDescriptors
+     * @status 400
+     */
+    test('should reject invalid AAS descriptor cursor with bad request', async () => {
+        const response = await client.getAllAssetAdministrationShellDescriptors({
+            configuration,
+            cursor: `does-not-exist-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation PutAssetAdministrationShellDescriptorById
+     * @status 201
+     */
+    test('should create an Asset Administration Shell Descriptor through put by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+
+        const response = await client.putAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(201);
+            expect(response.data).toEqual(shellDescriptor);
+        }
+    });
+
+    /**
+     * @operation PutAssetAdministrationShellDescriptorById
+     * @status 204
+     */
+    test('should update an Asset Administration Shell Descriptor through put by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createResponse.success).toBe(true);
+
+        const updatedShellDescriptor = createUniqueShellDescriptor();
+        updatedShellDescriptor.id = shellDescriptor.id;
+        updatedShellDescriptor.description = [createDescription()];
+
+        const response = await client.putAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
             assetAdministrationShellDescriptor: updatedShellDescriptor,
         });
 
-        expect(updateResponse.success).toBe(true);
-
-        const fetchResponse = await client.getAssetAdministrationShellDescriptorById({
-            configuration,
-            aasIdentifier: testShellDescriptor.id,
-        });
-
-        expect(fetchResponse.success).toBe(true);
-        if (fetchResponse.success) {
-            expect(fetchResponse.data).toBeDefined();
-            expect(fetchResponse.data).toEqual(updatedShellDescriptor);
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(204);
+            expect(response.data).toBeUndefined();
         }
     });
 
-    test('should create a new Submodel Descriptor', async () => {
+    /**
+     * @operation PutAssetAdministrationShellDescriptorById
+     * @status 400
+     */
+    test('should reject missing put AAS identifier with bad request', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+
+        const response = await client.putAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation DeleteAssetAdministrationShellDescriptorById
+     * @status 204
+     */
+    test('should delete an Asset Administration Shell Descriptor by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createResponse.success).toBe(true);
+
+        const response = await client.deleteAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+        });
+
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(204);
+            expect(response.data).toBeUndefined();
+        }
+    });
+
+    /**
+     * @operation DeleteAssetAdministrationShellDescriptorById
+     * @status 400
+     */
+    test('should reject missing delete AAS identifier with bad request', async () => {
+        const response = await client.deleteAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation DeleteAssetAdministrationShellDescriptorById
+     * @status 404
+     */
+    test('should return not found when deleting a non-existing Asset Administration Shell Descriptor', async () => {
+        const response = await client.deleteAssetAdministrationShellDescriptorById({
+            configuration,
+            aasIdentifier: `https://example.com/ids/aas-desc/non-existing-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation PostSubmodelDescriptor-ThroughSuperpath
+     * @status 201
+     */
+    test('should create a new Submodel Descriptor through superpath', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
         const response = await client.postSubmodelDescriptorThroughSuperpath({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
-            submodelDescriptor: testSubmodelDescriptor,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
         });
-        console.log('Submitted:', testSubmodelDescriptor);
 
         expect(response.success).toBe(true);
-
         if (response.success) {
-            console.log('Received:', response.data);
-            expect(response.data).toBeDefined();
-            expect(response.data?.id).toEqual(testSubmodelDescriptor.id);
-            expect(response.data?.endpoints).toEqual(testSubmodelDescriptor.endpoints);
-
-            expect(response.data).toEqual(testSubmodelDescriptor);
+            expect(response.statusCode).toBe(201);
+            expect(response.data).toEqual(submodelDescriptor);
         }
     });
 
-    test('should fetch a Submodel Descriptor by ID', async () => {
+    /**
+     * @operation PostSubmodelDescriptor-ThroughSuperpath
+     * @status 400
+     */
+    test('should reject missing superpath AAS identifier for submodel creation with bad request', async () => {
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+
+        const response = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+            submodelDescriptor,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation PostSubmodelDescriptor-ThroughSuperpath
+     * @status 404
+     */
+    test('should return not found when creating a Submodel Descriptor below a non-existing AAS', async () => {
+        const response = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: `https://example.com/ids/aas-desc/non-existing-${uniqueSuffix()}`,
+            submodelDescriptor: createUniqueSubmodelDescriptor(),
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation PostSubmodelDescriptor-ThroughSuperpath
+     * @status 409 [non-blocking]
+     */
+    test('should surface conflict status for duplicate submodel descriptor creation when backend enforces it', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const initialResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+        expect(initialResponse.success).toBe(true);
+
+        const duplicateResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+
+        if (duplicateResponse.success) {
+            expect([201, 204]).toContain(duplicateResponse.statusCode);
+        } else {
+            expect(duplicateResponse.statusCode).toBe(409);
+            expect(duplicateResponse.error.messages?.[0]?.code).toBe('409');
+        }
+    });
+
+    /**
+     * @operation GetSubmodelDescriptorByIdThroughSuperpath
+     * @status 200
+     */
+    test('should fetch a Submodel Descriptor by ID through superpath', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+        const createSubmodelResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+        expect(createSubmodelResponse.success).toBe(true);
+
         const response = await client.getSubmodelDescriptorByIdThroughSuperpath({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
-            submodelIdentifier: testSubmodelDescriptor.id,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: submodelDescriptor.id,
         });
 
         expect(response.success).toBe(true);
         if (response.success) {
-            expect(response.data).toBeDefined();
-            expect(response.data).toEqual(testSubmodelDescriptor);
+            expect(response.statusCode).toBe(200);
+            expect(response.data).toEqual(submodelDescriptor);
         }
     });
 
-    test('should fetch all Submodel Descriptors', async () => {
+    /**
+     * @operation GetSubmodelDescriptorByIdThroughSuperpath
+     * @status 400
+     */
+    test('should reject missing submodel superpath identifier with bad request', async () => {
+        const response = await client.getSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+            submodelIdentifier: createUniqueSubmodelDescriptor().id,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetSubmodelDescriptorByIdThroughSuperpath
+     * @status 404
+     */
+    test('should return not found for a non-existing Submodel Descriptor through superpath', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const response = await client.getSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: `https://example.com/ids/sm-desc/non-existing-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation GetAllSubmodelDescriptorsThroughSuperpath
+     * @status 200
+     */
+    test('should fetch all Submodel Descriptors through superpath', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+        const createSubmodelResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+        expect(createSubmodelResponse.success).toBe(true);
+
         const response = await client.getAllSubmodelDescriptorsThroughSuperpath({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
+            aasIdentifier: shellDescriptor.id,
         });
 
         expect(response.success).toBe(true);
         if (response.success) {
-            expect(response.data).toBeDefined();
+            expect(response.statusCode).toBe(200);
             expect(response.data.result.length).toBeGreaterThan(0);
-            expect(response.data.result).toContainEqual(testSubmodelDescriptor);
+            expect(response.data.result).toContainEqual(submodelDescriptor);
         }
     });
 
-    test('should update a Submodel Descriptor', async () => {
-        const updatedSubmodelDescriptor = testSubmodelDescriptor;
-        const displayName = createDisplayName();
-
-        updatedSubmodelDescriptor.displayName = [displayName];
-
-        const updateResponse = await client.putSubmodelDescriptorByIdThroughSuperpath({
+    /**
+     * @operation GetAllSubmodelDescriptorsThroughSuperpath
+     * @status 400
+     */
+    test('should reject invalid submodel descriptor paging parameters through superpath with bad request', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
-            submodelIdentifier: testSubmodelDescriptor.id,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const response = await client.getAllSubmodelDescriptorsThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            limit: -1,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetAllSubmodelDescriptorsThroughSuperpath
+     * @status 400
+     */
+    test('should reject invalid submodel descriptor cursor through superpath with bad request', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const response = await client.getAllSubmodelDescriptorsThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            cursor: `does-not-exist-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetAllSubmodelDescriptorsThroughSuperpath
+     * @status 404
+     */
+    test('should return not found when listing Submodel Descriptors below a non-existing AAS', async () => {
+        const response = await client.getAllSubmodelDescriptorsThroughSuperpath({
+            configuration,
+            aasIdentifier: `https://example.com/ids/aas-desc/non-existing-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation PutSubmodelDescriptorByIdThroughSuperpath
+     * @status 201
+     */
+    test('should create a Submodel Descriptor through superpath put by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const response = await client.putSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: submodelDescriptor.id,
+            submodelDescriptor,
+        });
+
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(201);
+            expect(response.data).toEqual(submodelDescriptor);
+        }
+    });
+
+    /**
+     * @operation PutSubmodelDescriptorByIdThroughSuperpath
+     * @status 204
+     */
+    test('should update a Submodel Descriptor through superpath put by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+        const createSubmodelResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+        expect(createSubmodelResponse.success).toBe(true);
+
+        const updatedSubmodelDescriptor = createUniqueSubmodelDescriptor();
+        updatedSubmodelDescriptor.id = submodelDescriptor.id;
+        updatedSubmodelDescriptor.displayName = [createDisplayName()];
+
+        const response = await client.putSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: submodelDescriptor.id,
             submodelDescriptor: updatedSubmodelDescriptor,
         });
 
-        expect(updateResponse.success).toBe(true);
-
-        const fetchResponse = await client.getSubmodelDescriptorByIdThroughSuperpath({
-            configuration,
-            aasIdentifier: testShellDescriptor.id,
-            submodelIdentifier: testSubmodelDescriptor.id,
-        });
-
-        expect(fetchResponse.success).toBe(true);
-        if (fetchResponse.success) {
-            expect(fetchResponse.data).toBeDefined();
-            expect(fetchResponse.data).toEqual(updatedSubmodelDescriptor);
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(204);
+            expect(response.data).toBeUndefined();
         }
     });
 
-    test('should delete a Submodel Descriptor through superpath', async () => {
+    /**
+     * @operation PutSubmodelDescriptorByIdThroughSuperpath
+     * @status 400
+     */
+    test('should reject missing superpath put AAS identifier with bad request', async () => {
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+
+        const response = await client.putSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: undefined as unknown as string,
+            submodelIdentifier: submodelDescriptor.id,
+            submodelDescriptor,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation PutSubmodelDescriptorByIdThroughSuperpath
+     * @status 404
+     */
+    test('should return not found when putting a Submodel Descriptor below a non-existing AAS', async () => {
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+
+        const response = await client.putSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: `https://example.com/ids/aas-desc/non-existing-${uniqueSuffix()}`,
+            submodelIdentifier: submodelDescriptor.id,
+            submodelDescriptor,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation DeleteSubmodelDescriptorByIdThroughSuperpath
+     * @status 204
+     */
+    test('should delete a Submodel Descriptor through superpath by ID', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const submodelDescriptor = createUniqueSubmodelDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+        const createSubmodelResponse = await client.postSubmodelDescriptorThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelDescriptor,
+        });
+        expect(createSubmodelResponse.success).toBe(true);
+
         const response = await client.deleteSubmodelDescriptorByIdThroughSuperpath({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
-            submodelIdentifier: testSubmodelDescriptor.id,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: submodelDescriptor.id,
         });
 
-        expect(typeof response.success).toBe('boolean');
-        if (!response.success) {
-            expect(response.error).toBeDefined();
+        expect(response.success).toBe(true);
+        if (response.success) {
+            expect(response.statusCode).toBe(204);
+            expect(response.data).toBeUndefined();
         }
     });
 
-    test('should delete an Asset Administration Shell Descriptor by ID', async () => {
-        const response = await client.deleteAssetAdministrationShellDescriptorById({
+    /**
+     * @operation DeleteSubmodelDescriptorByIdThroughSuperpath
+     * @status 400
+     */
+    test('should reject missing superpath delete AAS identifier with bad request', async () => {
+        const response = await client.deleteSubmodelDescriptorByIdThroughSuperpath({
             configuration,
-            aasIdentifier: testShellDescriptor.id,
+            aasIdentifier: undefined as unknown as string,
+            submodelIdentifier: createUniqueSubmodelDescriptor().id,
         });
 
-        expect(typeof response.success).toBe('boolean');
+        expect(response.success).toBe(false);
         if (!response.success) {
-            expect(response.error).toBeDefined();
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
         }
     });
 
+    /**
+     * @operation DeleteSubmodelDescriptorByIdThroughSuperpath
+     * @status 404
+     */
+    test('should return not found when deleting a non-existing Submodel Descriptor through superpath', async () => {
+        const shellDescriptor = createUniqueShellDescriptor();
+        const createShellResponse = await client.postAssetAdministrationShellDescriptor({
+            configuration,
+            assetAdministrationShellDescriptor: shellDescriptor,
+        });
+        expect(createShellResponse.success).toBe(true);
+
+        const response = await client.deleteSubmodelDescriptorByIdThroughSuperpath({
+            configuration,
+            aasIdentifier: shellDescriptor.id,
+            submodelIdentifier: `https://example.com/ids/sm-desc/non-existing-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(404);
+            expect(response.error.messages?.[0]?.code).toBe('404');
+        }
+    });
+
+    /**
+     * @operation GetSelfDescription
+     * @status 200
+     */
     test('should fetch AAS registry service description', async () => {
         const response = await client.getSelfDescription({
             configuration,
@@ -202,6 +822,7 @@ describe('AAS Registry Integration Tests', () => {
 
         expect(response.success).toBe(true);
         if (response.success) {
+            expect(response.statusCode).toBe(200);
             expect(response.data).toBeDefined();
             expect(Array.isArray(response.data.profiles)).toBe(true);
         }

--- a/src/integration-tests/submodelRegistry.integration.test.ts
+++ b/src/integration-tests/submodelRegistry.integration.test.ts
@@ -109,6 +109,23 @@ describe('Submodel Registry Integration Tests', () => {
 
     /**
      * @operation GetSubmodelDescriptorById
+     * @status 400
+     */
+    test('should reject missing Submodel Descriptor identifier with bad request', async () => {
+        const response = await client.getSubmodelDescriptorById({
+            configuration,
+            submodelIdentifier: undefined as unknown as string,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
+     * @operation GetSubmodelDescriptorById
      * @status 404
      */
     test('should fetch a Submodel Descriptor by non-existing ID', async () => {
@@ -183,6 +200,23 @@ describe('Submodel Registry Integration Tests', () => {
     });
 
     /**
+     * @operation GetAllSubmodelDescriptors
+     * @status 400
+     */
+    test('should return bad request for unavailable Submodel Descriptor ID used as cursor', async () => {
+        const response = await client.getAllSubmodelDescriptors({
+            configuration,
+            cursor: `does-not-exist-${uniqueSuffix()}`,
+        });
+
+        expect(response.success).toBe(false);
+        if (!response.success) {
+            expect(response.statusCode).toBe(400);
+            expect(response.error.messages?.[0]?.code).toBe('400');
+        }
+    });
+
+    /**
      * @operation PutSubmodelDescriptorById
      * @status 201
      */
@@ -244,36 +278,15 @@ describe('Submodel Registry Integration Tests', () => {
 
     /**
      * @operation PutSubmodelDescriptorById
-     * @status 405
+     * @status 400
      */
-    test('should return method not allowed for malformed put identifier (backend mismatch)', async () => {
+    test('should reject missing put Submodel Descriptor identifier with bad request', async () => {
         const submodelDescriptor = createUniqueSubmodelDescriptor();
         submodelDescriptor.id = '';
 
         const response = await client.putSubmodelDescriptorById({
             configuration,
-            submodelIdentifier: '',
-            submodelDescriptor,
-        });
-
-        expect(response.success).toBe(false);
-        if (!response.success) {
-            expect(response.statusCode).toBe(405);
-            expect(response.error.messages?.[0]?.code).toBe('405');
-        }
-    });
-
-    /**
-     * @operation PutSubmodelDescriptorById
-     * @status 400 [known-backend-bug]
-     */
-    test.skip('should reject malformed put identifier with bad request', async () => {
-        const submodelDescriptor = createUniqueSubmodelDescriptor();
-        submodelDescriptor.id = '';
-
-        const response = await client.putSubmodelDescriptorById({
-            configuration,
-            submodelIdentifier: '',
+            submodelIdentifier: undefined as unknown as string,
             submodelDescriptor,
         });
 
@@ -329,29 +342,12 @@ describe('Submodel Registry Integration Tests', () => {
 
     /**
      * @operation DeleteSubmodelDescriptorById
-     * @status 405
+     * @status 400
      */
-    test('should reject malformed delete identifier with method not allowed', async () => {
+    test('should reject missing delete Submodel Descriptor identifier with bad request', async () => {
         const response = await client.deleteSubmodelDescriptorById({
             configuration,
-            submodelIdentifier: '',
-        });
-
-        expect(response.success).toBe(false);
-        if (!response.success) {
-            expect(response.statusCode).toBe(405);
-            expect(response.error.messages?.[0]?.code).toBe('405');
-        }
-    });
-
-    /**
-     * @operation DeleteSubmodelDescriptorById
-     * @status 400 [known-backend-bug]
-     */
-    test.skip('should reject malformed delete identifier with bad request', async () => {
-        const response = await client.deleteSubmodelDescriptorById({
-            configuration,
-            submodelIdentifier: '',
+            submodelIdentifier: undefined as unknown as string,
         });
 
         expect(response.success).toBe(false);

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -9,6 +9,22 @@ import {
     SubmodelRepositoryService,
 } from '../generated';
 import { FetchError, RequiredError, ResponseError } from '../generated/runtime';
+
+function getResponseStatus(err: unknown): number | undefined {
+    const response = (err as { response?: { status?: unknown } })?.response;
+    return typeof response?.status === 'number' ? response.status : undefined;
+}
+
+function isResponseErrorLike(err: unknown): err is { message?: string; response: Response } {
+    return (
+        getResponseStatus(err) !== undefined &&
+        typeof (err as { response?: { json?: unknown } }).response?.json === 'function'
+    );
+}
+
+function isRequiredErrorLike(err: unknown): err is { message?: string; field?: string } {
+    return err instanceof RequiredError || (err as { name?: unknown })?.name === 'RequiredError';
+}
 /**
  * Processes errors from API calls and standardizes them to a Result object
  * with a consistent messages array following the API spec guidelines.
@@ -52,14 +68,14 @@ export async function handleApiError(
         };
 
         // Handle different error types
-        if (err instanceof RequiredError) {
+        if (isRequiredErrorLike(err)) {
             message = {
                 code: '400',
                 messageType: 'Exception',
                 text: err.message || `Required parameter missing: ${err.field}`,
                 timestamp: timestamp,
             };
-        } else if (err instanceof ResponseError) {
+        } else if (err instanceof ResponseError || isResponseErrorLike(err)) {
             // Try to parse response body for messages
             const responseBody = err.response;
 

--- a/src/unit-tests/clients/AasRegistryClient.test.ts
+++ b/src/unit-tests/clients/AasRegistryClient.test.ts
@@ -108,6 +108,10 @@ const TEST_CONFIGURATION = new Configuration({
 const SERVICE_DESCRIPTION: AasRegistryService.ServiceDescription = {
     profiles: ['aas-registry-service-profile'],
 };
+const apiResponse = <T>(value: T, status = 200) => ({
+    raw: { status },
+    value: vi.fn().mockResolvedValue(value),
+});
 
 describe('AasRegistryClient', () => {
     // Helper function to create expected configuration matcher
@@ -119,17 +123,17 @@ describe('AasRegistryClient', () => {
 
     // Create mock for AssetAdministrationShellRegistryAPIApi
     const mockApiInstance = {
-        getAllAssetAdministrationShellDescriptors: vi.fn(),
-        postAssetAdministrationShellDescriptor: vi.fn(),
-        deleteAssetAdministrationShellDescriptorById: vi.fn(),
-        getAssetAdministrationShellDescriptorById: vi.fn(),
-        putAssetAdministrationShellDescriptorById: vi.fn(),
-        getAllSubmodelDescriptorsThroughSuperpath: vi.fn(),
-        postSubmodelDescriptorThroughSuperpath: vi.fn(),
-        getSubmodelDescriptorByIdThroughSuperpath: vi.fn(),
-        deleteSubmodelDescriptorByIdThroughSuperpath: vi.fn(),
-        putSubmodelDescriptorByIdThroughSuperpath: vi.fn(),
-        getSelfDescription: vi.fn(),
+        getAllAssetAdministrationShellDescriptorsRaw: vi.fn(),
+        postAssetAdministrationShellDescriptorRaw: vi.fn(),
+        deleteAssetAdministrationShellDescriptorByIdRaw: vi.fn(),
+        getAssetAdministrationShellDescriptorByIdRaw: vi.fn(),
+        putAssetAdministrationShellDescriptorByIdRaw: vi.fn(),
+        getAllSubmodelDescriptorsThroughSuperpathRaw: vi.fn(),
+        postSubmodelDescriptorThroughSuperpathRaw: vi.fn(),
+        getSubmodelDescriptorByIdThroughSuperpathRaw: vi.fn(),
+        deleteSubmodelDescriptorByIdThroughSuperpathRaw: vi.fn(),
+        putSubmodelDescriptorByIdThroughSuperpathRaw: vi.fn(),
+        getSelfDescriptionRaw: vi.fn(),
     };
 
     // Mock constructor
@@ -200,10 +204,15 @@ describe('AasRegistryClient', () => {
         const pagedResult: AasRegistryService.PagedResultPagingMetadata = {
             cursor: CURSOR,
         };
-        mockApiInstance.getAllAssetAdministrationShellDescriptors.mockResolvedValue({
-            pagingMetadata: pagedResult,
-            result: [API_AAS_DESCRIPTOR1, API_AAS_DESCRIPTOR2],
-        });
+        mockApiInstance.getAllAssetAdministrationShellDescriptorsRaw.mockResolvedValue(
+            apiResponse(
+                {
+                    pagingMetadata: pagedResult,
+                    result: [API_AAS_DESCRIPTOR1, API_AAS_DESCRIPTOR2],
+                },
+                200
+            )
+        );
 
         const client = new AasRegistryClient();
 
@@ -218,7 +227,7 @@ describe('AasRegistryClient', () => {
 
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
-        expect(mockApiInstance.getAllAssetAdministrationShellDescriptors).toHaveBeenCalledWith({
+        expect(mockApiInstance.getAllAssetAdministrationShellDescriptorsRaw).toHaveBeenCalledWith({
             limit: LIMIT,
             cursor: CURSOR,
             assetKind: ASSET_KIND,
@@ -245,7 +254,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.getAllAssetAdministrationShellDescriptors.mockRejectedValue(
+        mockApiInstance.getAllAssetAdministrationShellDescriptorsRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -266,7 +275,9 @@ describe('AasRegistryClient', () => {
 
     it('should create a new Asset Administration Shell Descriptor', async () => {
         // Arrange
-        mockApiInstance.postAssetAdministrationShellDescriptor.mockResolvedValue(API_AAS_DESCRIPTOR1);
+        mockApiInstance.postAssetAdministrationShellDescriptorRaw.mockResolvedValue(
+            apiResponse(API_AAS_DESCRIPTOR1, 201)
+        );
 
         const client = new AasRegistryClient();
 
@@ -278,7 +289,7 @@ describe('AasRegistryClient', () => {
 
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
-        expect(mockApiInstance.postAssetAdministrationShellDescriptor).toHaveBeenCalledWith({
+        expect(mockApiInstance.postAssetAdministrationShellDescriptorRaw).toHaveBeenCalledWith({
             assetAdministrationShellDescriptor: API_AAS_DESCRIPTOR1,
         });
         expect(convertCoreAasDescriptorToApiAasDescriptor).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1);
@@ -301,7 +312,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.postAssetAdministrationShellDescriptor.mockRejectedValue(
+        mockApiInstance.postAssetAdministrationShellDescriptorRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -323,7 +334,7 @@ describe('AasRegistryClient', () => {
 
     it('should delete an Asset Administration Shell Descriptor', async () => {
         // Arrange
-        mockApiInstance.deleteAssetAdministrationShellDescriptorById.mockResolvedValue(undefined);
+        mockApiInstance.deleteAssetAdministrationShellDescriptorByIdRaw.mockResolvedValue(apiResponse(undefined, 204));
 
         const client = new AasRegistryClient();
 
@@ -336,7 +347,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.deleteAssetAdministrationShellDescriptorById).toHaveBeenCalledWith({
+        expect(mockApiInstance.deleteAssetAdministrationShellDescriptorByIdRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
         });
         expect(response.success).toBe(true);
@@ -354,7 +365,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.deleteAssetAdministrationShellDescriptorById.mockRejectedValue(
+        mockApiInstance.deleteAssetAdministrationShellDescriptorByIdRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -376,7 +387,9 @@ describe('AasRegistryClient', () => {
 
     it('should get an Asset Administration Shell Descriptor by ID', async () => {
         // Arrange
-        mockApiInstance.getAssetAdministrationShellDescriptorById.mockResolvedValue(API_AAS_DESCRIPTOR1);
+        mockApiInstance.getAssetAdministrationShellDescriptorByIdRaw.mockResolvedValue(
+            apiResponse(API_AAS_DESCRIPTOR1, 200)
+        );
 
         const client = new AasRegistryClient();
 
@@ -389,7 +402,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.getAssetAdministrationShellDescriptorById).toHaveBeenCalledWith({
+        expect(mockApiInstance.getAssetAdministrationShellDescriptorByIdRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
         });
         expect(convertApiAasDescriptorToCoreAasDescriptor).toHaveBeenCalledWith(API_AAS_DESCRIPTOR1);
@@ -411,7 +424,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.getAssetAdministrationShellDescriptorById.mockRejectedValue(
+        mockApiInstance.getAssetAdministrationShellDescriptorByIdRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -433,7 +446,7 @@ describe('AasRegistryClient', () => {
 
     it('should update an Asset Administration Shell Descriptor', async () => {
         // Arrange
-        mockApiInstance.putAssetAdministrationShellDescriptorById.mockResolvedValue(undefined);
+        mockApiInstance.putAssetAdministrationShellDescriptorByIdRaw.mockResolvedValue(apiResponse(undefined, 204));
 
         const client = new AasRegistryClient();
 
@@ -447,7 +460,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.putAssetAdministrationShellDescriptorById).toHaveBeenCalledWith({
+        expect(mockApiInstance.putAssetAdministrationShellDescriptorByIdRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             assetAdministrationShellDescriptor: API_AAS_DESCRIPTOR1,
         });
@@ -457,7 +470,9 @@ describe('AasRegistryClient', () => {
 
     it('should create a new Asset Administration Shell Descriptor', async () => {
         // Arrange
-        mockApiInstance.putAssetAdministrationShellDescriptorById.mockResolvedValue(API_AAS_DESCRIPTOR1);
+        mockApiInstance.putAssetAdministrationShellDescriptorByIdRaw.mockResolvedValue(
+            apiResponse(API_AAS_DESCRIPTOR1, 201)
+        );
 
         const client = new AasRegistryClient();
 
@@ -471,7 +486,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.putAssetAdministrationShellDescriptorById).toHaveBeenCalledWith({
+        expect(mockApiInstance.putAssetAdministrationShellDescriptorByIdRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             assetAdministrationShellDescriptor: API_AAS_DESCRIPTOR1,
         });
@@ -494,7 +509,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.putAssetAdministrationShellDescriptorById.mockRejectedValue(
+        mockApiInstance.putAssetAdministrationShellDescriptorByIdRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -520,10 +535,15 @@ describe('AasRegistryClient', () => {
         const pagedResult: AasRegistryService.PagedResultPagingMetadata = {
             cursor: CURSOR,
         };
-        mockApiInstance.getAllSubmodelDescriptorsThroughSuperpath.mockResolvedValue({
-            pagingMetadata: pagedResult,
-            result: [API_SUBMODEL_DESCRIPTOR1, API_SUBMODEL_DESCRIPTOR2],
-        });
+        mockApiInstance.getAllSubmodelDescriptorsThroughSuperpathRaw.mockResolvedValue(
+            apiResponse(
+                {
+                    pagingMetadata: pagedResult,
+                    result: [API_SUBMODEL_DESCRIPTOR1, API_SUBMODEL_DESCRIPTOR2],
+                },
+                200
+            )
+        );
 
         const client = new AasRegistryClient();
 
@@ -538,7 +558,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.getAllSubmodelDescriptorsThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.getAllSubmodelDescriptorsThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             limit: LIMIT,
             cursor: CURSOR,
@@ -564,7 +584,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.getAllSubmodelDescriptorsThroughSuperpath.mockRejectedValue(
+        mockApiInstance.getAllSubmodelDescriptorsThroughSuperpathRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -586,7 +606,9 @@ describe('AasRegistryClient', () => {
 
     it('should create a new Submodel Descriptor', async () => {
         // Arrange
-        mockApiInstance.postSubmodelDescriptorThroughSuperpath.mockResolvedValue(API_SUBMODEL_DESCRIPTOR1);
+        mockApiInstance.postSubmodelDescriptorThroughSuperpathRaw.mockResolvedValue(
+            apiResponse(API_SUBMODEL_DESCRIPTOR1, 201)
+        );
 
         const client = new AasRegistryClient();
 
@@ -600,7 +622,7 @@ describe('AasRegistryClient', () => {
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
-        expect(mockApiInstance.postSubmodelDescriptorThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.postSubmodelDescriptorThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             submodelDescriptor: API_SUBMODEL_DESCRIPTOR1,
         });
@@ -624,7 +646,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.postSubmodelDescriptorThroughSuperpath.mockRejectedValue(
+        mockApiInstance.postSubmodelDescriptorThroughSuperpathRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -647,7 +669,9 @@ describe('AasRegistryClient', () => {
 
     it('should get a Submodel Descriptor by ID', async () => {
         // Arrange
-        mockApiInstance.getSubmodelDescriptorByIdThroughSuperpath.mockResolvedValue(API_SUBMODEL_DESCRIPTOR1);
+        mockApiInstance.getSubmodelDescriptorByIdThroughSuperpathRaw.mockResolvedValue(
+            apiResponse(API_SUBMODEL_DESCRIPTOR1, 200)
+        );
 
         const client = new AasRegistryClient();
 
@@ -662,7 +686,7 @@ describe('AasRegistryClient', () => {
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
         expect(base64Encode).toHaveBeenCalledWith(CORE_SUBMODEL_DESCRIPTOR1.id);
-        expect(mockApiInstance.getSubmodelDescriptorByIdThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.getSubmodelDescriptorByIdThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             submodelIdentifier: `encoded_${CORE_SUBMODEL_DESCRIPTOR1.id}`,
         });
@@ -685,7 +709,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.getSubmodelDescriptorByIdThroughSuperpath.mockRejectedValue(
+        mockApiInstance.getSubmodelDescriptorByIdThroughSuperpathRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -708,7 +732,7 @@ describe('AasRegistryClient', () => {
 
     it('should delete a Submodel Descriptor', async () => {
         // Arrange
-        mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpath.mockResolvedValue(undefined);
+        mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpathRaw.mockResolvedValue(apiResponse(undefined, 204));
 
         const client = new AasRegistryClient();
 
@@ -723,7 +747,7 @@ describe('AasRegistryClient', () => {
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
         expect(base64Encode).toHaveBeenCalledWith(CORE_SUBMODEL_DESCRIPTOR1.id);
-        expect(mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             submodelIdentifier: `encoded_${CORE_SUBMODEL_DESCRIPTOR1.id}`,
         });
@@ -742,7 +766,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpath.mockRejectedValue(
+        mockApiInstance.deleteSubmodelDescriptorByIdThroughSuperpathRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -765,7 +789,7 @@ describe('AasRegistryClient', () => {
 
     it('should update a Submodel Descriptor', async () => {
         // Arrange
-        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpath.mockResolvedValue(undefined);
+        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw.mockResolvedValue(apiResponse(undefined, 204));
 
         const client = new AasRegistryClient();
 
@@ -781,7 +805,7 @@ describe('AasRegistryClient', () => {
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
         expect(base64Encode).toHaveBeenCalledWith(CORE_SUBMODEL_DESCRIPTOR1.id);
-        expect(mockApiInstance.putSubmodelDescriptorByIdThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             submodelIdentifier: `encoded_${CORE_SUBMODEL_DESCRIPTOR1.id}`,
             submodelDescriptor: API_SUBMODEL_DESCRIPTOR1,
@@ -792,7 +816,9 @@ describe('AasRegistryClient', () => {
 
     it('should create a new Submodel Descriptor during update', async () => {
         // Arrange
-        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpath.mockResolvedValue(API_SUBMODEL_DESCRIPTOR1);
+        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw.mockResolvedValue(
+            apiResponse(API_SUBMODEL_DESCRIPTOR1, 201)
+        );
 
         const client = new AasRegistryClient();
 
@@ -808,7 +834,7 @@ describe('AasRegistryClient', () => {
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
         expect(base64Encode).toHaveBeenCalledWith(CORE_AAS_DESCRIPTOR1.id);
         expect(base64Encode).toHaveBeenCalledWith(CORE_SUBMODEL_DESCRIPTOR1.id);
-        expect(mockApiInstance.putSubmodelDescriptorByIdThroughSuperpath).toHaveBeenCalledWith({
+        expect(mockApiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw).toHaveBeenCalledWith({
             aasIdentifier: `encoded_${CORE_AAS_DESCRIPTOR1.id}`,
             submodelIdentifier: `encoded_${CORE_SUBMODEL_DESCRIPTOR1.id}`,
             submodelDescriptor: API_SUBMODEL_DESCRIPTOR1,
@@ -832,7 +858,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpath.mockRejectedValue(
+        mockApiInstance.putSubmodelDescriptorByIdThroughSuperpathRaw.mockRejectedValue(
             new Error('Required parameter missing')
         );
         (handleApiError as Mock).mockResolvedValue(errorResult);
@@ -856,7 +882,7 @@ describe('AasRegistryClient', () => {
 
     it('should return service description', async () => {
         // Arrange
-        mockApiInstance.getSelfDescription.mockResolvedValue(SERVICE_DESCRIPTION);
+        mockApiInstance.getSelfDescriptionRaw.mockResolvedValue(apiResponse(SERVICE_DESCRIPTION, 200));
 
         const client = new AasRegistryClient();
 
@@ -867,7 +893,7 @@ describe('AasRegistryClient', () => {
 
         // Assert
         expect(MockAasRegistry).toHaveBeenCalledWith(expectConfigurationCall());
-        expect(mockApiInstance.getSelfDescription).toHaveBeenCalledWith();
+        expect(mockApiInstance.getSelfDescriptionRaw).toHaveBeenCalledWith();
         expect(response.success).toBe(true);
         if (response.success) {
             expect(response.data).toEqual(SERVICE_DESCRIPTION);
@@ -886,7 +912,7 @@ describe('AasRegistryClient', () => {
                 },
             ],
         };
-        mockApiInstance.getSelfDescription.mockRejectedValue(new Error('Required parameter missing'));
+        mockApiInstance.getSelfDescriptionRaw.mockRejectedValue(new Error('Required parameter missing'));
         (handleApiError as Mock).mockResolvedValue(errorResult);
 
         const client = new AasRegistryClient();


### PR DESCRIPTION
This pull request introduces support for the new `AasRegistryClient` and improves error handling and response status reporting throughout the client code. It also enhances the OpenAPI coverage validation tooling to support the new service and to better map OpenAPI operation IDs to client method names. The most significant changes are grouped below.

### AAS Registry Client enhancements

* Added a new `AasRegistryClient` with methods that wrap the generated API, providing improved error handling and always returning HTTP status codes in responses. All identifier parameters are now validated to prevent null, undefined, or empty values, throwing a `RequiredError` if validation fails. [[1]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L4-R4) [[2]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383R17-R43)
* All client methods now use the `Raw` API endpoints to access the HTTP response status, which is included in the returned result. [[1]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L52-R99) [[2]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L90-R141) [[3]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L123-R181) [[4]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L156-R225) [[5]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L191-R279) [[6]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L238-R337) [[7]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L279-R384) [[8]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L315-R434) [[9]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L352-R480) [[10]](diffhunk://#diff-eec701671a97687430f5f8df9c8e8d05642e0acaa6fc180bccd6d9feb2a92383L391-R538)
* Improved error handling by extracting the HTTP status code from errors (including custom logic for `RequiredError`) and including it in the error result.

### OpenAPI Coverage Validation improvements

* Added support for the `aasRegistry` service in the OpenAPI coverage validation script and as an npm script. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R41) [[2]](diffhunk://#diff-720229642695faaee89550d3303f72d6b3a98a5d57dbe37272b663611b9cd240R16-R20)
* Improved the mapping from OpenAPI `operationId` to client method names by introducing the `operationIdToMethodName` function, which normalizes operation IDs to camelCase. This ensures more accurate coverage reports. [[1]](diffhunk://#diff-720229642695faaee89550d3303f72d6b3a98a5d57dbe37272b663611b9cd240R46-R52) [[2]](diffhunk://#diff-720229642695faaee89550d3303f72d6b3a98a5d57dbe37272b663611b9cd240L221-R233)
* Updated the parsing of `@operation` tags in integration test metadata to support hyphens in operation IDs.

### AAS Discovery Client fix

* Improved extraction of HTTP status codes from errors in `AasDiscoveryClient`, including fallback for `RequiredError` cases.